### PR TITLE
fix: auto-reconnect on connection lost if parameter enabled

### DIFF
--- a/lib/driver/aws-sigv4-driver-remote-connection.js
+++ b/lib/driver/aws-sigv4-driver-remote-connection.js
@@ -129,6 +129,13 @@ class AwsSigV4DriverRemoteConnection extends gremlin.driver.RemoteConnection {
     return new Promise((resolve, reject) => {
       const queryId = uuid();
       this._rejections[queryId] = reject;
+      if (this._client == null) {
+        if (this.options.autoReconnect) {
+          this._connectSocket();
+        } else {
+          reject(new Error('Disconnected from database'));
+        }
+      }
       this._client.submit(bytecode)
         .then((result) => {
           delete this._rejections[queryId];


### PR DESCRIPTION
Sometimes Neptune interrupts the connection, and it makes the submit function fail. 
This PR enable auto-reconnecting from the submit function when the option `autoReconnect` is set to true.