### PR TITLE
Replace deprecated connectOnStartup option

### DIFF
--- a/lib/driver/aws-sigv4-driver-remote-connection.js
+++ b/lib/driver/aws-sigv4-driver-remote-connection.js
@@ -20,7 +20,6 @@ class AwsSigV4DriverRemoteConnection extends gremlin.driver.RemoteConnection {
     this.maxRetry = this.options.maxRetry || 10;
 
     this.clientOptions = {
-      connectOnStartup: true,
       mimeType: 'application/vnd.gremlin-v2.0+json',
       pingEnabled: true,
       pingInterval: 1000,
@@ -68,6 +67,7 @@ class AwsSigV4DriverRemoteConnection extends gremlin.driver.RemoteConnection {
     const { url, headers } = getUrlAndHeaders(this.host, this.port, this.options, '/gremlin', this.secure ? 'wss' : 'ws');
     debug(`connect: ${JSON.stringify(url, headers)} (try #${this.try})`);
     this._client = new gremlin.driver.Client(url, ({ headers, ...this.clientOptions }));
+    this._client.open();
     this._client._connection.on('log', (log) => this._logHandler(log));
     this._client._connection.on('close', (code, message) => this._closeHandler(code, message));
     this._client._connection.on('error', (error) => this._errorHandler(error));


### PR DESCRIPTION
This PR replaces the deprecated "connectOnStartup" option with an explicit call to `_client.open()` .

`connectOnStartup` was deprecated and removed in version 3.5.4 of Gremlin: https://github.com/apache/tinkerpop/blob/master/CHANGELOG.asciidoc#tinkerpop-354-release-date-july-18-2022

